### PR TITLE
Reproducing the Crash When Choosing eID for Identification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,6 +101,12 @@ dependencies {
     implementation 'de.idnow.sdk:idnow-android-sdk:8.5.0'
     implementation 'de.idnow.android.eid:idnow-android-eid-sdk:2.12.0'
     implementation "androidx.multidex:multidex:2.0.1"
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"){
+        force = true
+    }
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"){
+        force = true
+    }
     implementation files ('libs/bcprov-jdk15to18-164.jar')
     implementation files ('libs/bctls-jdk15to18-164.jar')
 }


### PR DESCRIPTION
## Background:
The crash occurs when selecting eID as the method for identification due to a deprecated API in the `org.jetbrains.kotlinx:kotlinx-coroutines-core` package used by the `idnow-android-eid-sdk`.
## Root Cause:
The `de.authada.library`, which is used by the `idnow-android-eid-sdk`, relies on an older version (1.3.4) of the `org.jetbrains.kotlinx:kotlinx-coroutines-core` library. A method within this version has since been deprecated, leading to the crash, as discussed in [this pull request](https://github.com/Kotlin/kotlinx.coroutines/pull/2918).
## Possible Solution:
Upon reviewing the dependency tree of the idnow-android-eid-sdk, it appears that more recent versions of the de.authada.library exist. The latest version is 4.23.0, as found [here](https://repo.authada.de/public/de/authada/library/aal/4.23.0/) (requires authentication for access).
To address this issue, the version of de.authada.library used in the idnow-android-eid-sdk should be updated. For instance, if the current implementation looks like this:
> implementation("de.authada.library:aal:4.15.2")

It should be updated to:

> implementation("de.authada.library:aal:4.23.0")

This update is likely to resolve the issue or at least help mitigate it on the IDNow side.