### PR TITLE
Using 8.6.0 is failing - see description in message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
     }
 }
 


### PR DESCRIPTION
The project is using an incompatible version (AGP 8.6.0) of the Android Gradle plugin. Latest supported version is AGP 8.5.0